### PR TITLE
fix bug: add shell=True and it works on Windows now

### DIFF
--- a/pyecharts_snapshot/main.py
+++ b/pyecharts_snapshot/main.py
@@ -30,10 +30,17 @@ def main():
 
 
 def make_a_snapshot(file_name, output_name):
+    # proc = subprocess.Popen(
+    #     ['phantomjs',
+    #      os.path.join(get_resource_dir('phantomjs'), 'snapshot.js'),
+    #      file_name], stdout=subprocess.PIPE)
+
+    # add shell=True and it works on Windows now.
     proc = subprocess.Popen(
         ['phantomjs',
          os.path.join(get_resource_dir('phantomjs'), 'snapshot.js'),
-         file_name], stdout=subprocess.PIPE)
+         file_name], stdout=subprocess.PIPE, shell=True)
+
     if PY2:
         content = proc.stdout.read()
         content = content.decode('utf-8')


### PR DESCRIPTION
pip 安装后试用了一下，在 Windows 下出现下列问题

![image_22](https://user-images.githubusercontent.com/19553554/29483505-8ef4f0a2-84da-11e7-8eda-96b99dec31c5.png)

看了一下 subprocess.py 的源码，里面 shell 参数跟 Windows 的 cmd.exe 有关，设置为 True 后，Windows 下保存为 pdf 和 png 均已没问题。